### PR TITLE
Fix index length bug

### DIFF
--- a/includes/CargoUtils.php
+++ b/includes/CargoUtils.php
@@ -713,7 +713,7 @@ class CargoUtils {
 			}
 		}
 		$createSQL .= ' )';
-		$createSQL .= '  ROW_FORMAT=DYNAMIC'; //prevent 1709 Error in use UTF-8 MySQL
+		$createSQL .= '  ROW_FORMAT=DYNAMIC'; //prevent 1709 Error in MySQL used UTF-8 charset
 
 		// For MySQL 5.6 and earlier, only MyISAM supports 'FULLTEXT'
 		// indexes; InnoDB does not.

--- a/includes/CargoUtils.php
+++ b/includes/CargoUtils.php
@@ -713,6 +713,7 @@ class CargoUtils {
 			}
 		}
 		$createSQL .= ' )';
+		$createSQL .= '  ROW_FORMAT=DYNAMIC'; //prevent 1709 Error in use UTF-8 MySQL
 
 		// For MySQL 5.6 and earlier, only MyISAM supports 'FULLTEXT'
 		// indexes; InnoDB does not.


### PR DESCRIPTION
prevent 1709 Error in MySQL used UTF-8 charset.

I use MariaDB and set default charset is UTF-8.
mediawiki 1.31 with Cargo 1.31 make error like next box.

> index column size too large. the maximum column size is 767 bytes

I add next line in create table line at CargoUtils.php and fixed this bug.

```
diff --git a/includes/CargoUtils.php b/includes/CargoUtils.php
index f883c5e..2b737b5 100644
--- a/includes/CargoUtils.php
+++ b/includes/CargoUtils.php
@@ -713,6 +713,7 @@ class CargoUtils {
                        }
                }
                $createSQL .= ' )';
+               $createSQL .= '  ROW_FORMAT=DYNAMIC'; //prevent 1709 Error in MySQL used UTF-8 charset
 
                // For MySQL 5.6 and earlier, only MyISAM supports 'FULLTEXT'
                // indexes; InnoDB does not.
```