### PR TITLE
Update CargoTableDiagram.php to put link under Cargo heading

### DIFF
--- a/includes/specials/CargoTableDiagram.php
+++ b/includes/specials/CargoTableDiagram.php
@@ -44,4 +44,9 @@ class CargoTableDiagram extends IncludableSpecialPage {
 
 		return true;
 	}
+	
+	protected function getGroupName() {
+		return 'cargo';
+	}
+
 }


### PR DESCRIPTION
The link to Cargo Table Diagram on Special Pages was under heading "Other special pages" rather than under "Cargo". This moves it under the Cargo heading. 